### PR TITLE
Build: Improvements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,10 @@
 
 ## Local development
 
-Start a tsc watcher in a terminal window:
+Start a tsc and tsup for development.
 
 ```shell
-npm run watch
-```
-
-Bundle the plugin with tsup:
-
-```shell
-npm run tsup:watch
-```
-
-Run unit tests:
-
-```shell
-npm run test
+npm run start
 ```
 
 ### Testing the eslint plugin in a Grafana plugin
@@ -39,7 +27,6 @@ For your Grafana plugin to pickup your local changes, you may need to disable es
 ```shell
 npm run version patch|minor|major
 npm run build
-npm run tsup
 # to publish, you need to be login to the Grafana org at NPM
 npm publish
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@grafana/eslint-plugin-is-compatible",
-  "version": "0.0.1",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@grafana/eslint-plugin-is-compatible",
-      "version": "0.0.1",
+      "version": "0.0.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@esm2cjs/execa": "^6.1.1-cjs.1",
@@ -23,6 +23,7 @@
         "@types/eslint": "^8.56.10",
         "@typescript-eslint/parser": "^7.13.0",
         "@typescript-eslint/rule-tester": "^7.13.0",
+        "concurrently": "^9.1.2",
         "eslint-doc-generator": "^1.7.1",
         "tsup": "^8.1.0",
         "vitest": "^1.6.0"
@@ -1385,6 +1386,48 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "license": "MIT"
+    },
+    "node_modules/concurrently": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-9.1.2.tgz",
+      "integrity": "sha512-H9MWcoPsYddwbOGM6difjVwVZHl63nwMEwDJG/L7VGtuaJhb12h2caPG2tVPWs7emuYix252iGfqOyrz1GczTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "lodash": "^4.17.21",
+        "rxjs": "^7.8.1",
+        "shell-quote": "^1.8.1",
+        "supports-color": "^8.1.1",
+        "tree-kill": "^1.2.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "conc": "dist/bin/concurrently.js",
+        "concurrently": "dist/bin/concurrently.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
+      }
+    },
+    "node_modules/concurrently/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
     },
     "node_modules/confbox": {
       "version": "0.1.8",
@@ -3577,6 +3620,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4692,6 +4742,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -4796,6 +4856,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shell-quote": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
+      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -62,11 +62,14 @@
   },
   "tsup": {
     "entry": [
-      "./src"
+      "./src",
+      "!src/**/*.spec.ts"
     ],
     "format": [
       "cjs"
     ],
-    "clean": true
+    "clean": true,
+    "bundle": false,
+    "shims": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/index.js",
   "files": [
     "docs/",
-    "lib/",
     "dist/"
   ],
   "publishConfig": {
@@ -31,13 +30,13 @@
   },
   "bugs": "https://github.com/grafana/eslint-plugin-is-compatible/issues",
   "scripts": {
-    "build": "tsc --build",
-    "build:diagnostics": "tsc --build --diagnostics",
-    "watch": "tsc --watch",
-    "tsup": "tsup ./lib",
-    "tsup:watch": "tsup ./lib --watch",
+    "build": "tsup",
+    "build:watch": "tsup --watch",
     "docs:init": "eslint-doc-generator --init-rule-docs",
     "docs:update": "eslint-doc-generator",
+    "start": "concurrently --names TSC,TSUP -c cyan,magenta \"npm run typecheck:watch\" \"npm run build:watch\"",
+    "typecheck": "tsc --noEmit",
+    "typecheck:watch": "tsc --watch --noEmit",
     "test": "vitest"
   },
   "license": "Apache-2.0",
@@ -56,8 +55,18 @@
     "@types/eslint": "^8.56.10",
     "@typescript-eslint/parser": "^7.13.0",
     "@typescript-eslint/rule-tester": "^7.13.0",
+    "concurrently": "^9.1.2",
     "eslint-doc-generator": "^1.7.1",
     "tsup": "^8.1.0",
     "vitest": "^1.6.0"
+  },
+  "tsup": {
+    "entry": [
+      "./src"
+    ],
+    "format": [
+      "cjs"
+    ],
+    "clean": true
   }
 }

--- a/src/rules/installPackages.ts
+++ b/src/rules/installPackages.ts
@@ -1,18 +1,13 @@
-import fs from 'fs';
-import path from 'path';
-import { Worker, MessageChannel, receiveMessageOnPort } from 'worker_threads';
+import path from "path";
+import { Worker, MessageChannel, receiveMessageOnPort } from "worker_threads";
 
 export function installPackages(packageVersion: string) {
   const { port1: localPort, port2: workerPort } = new MessageChannel();
   const shared = new SharedArrayBuffer(4);
   const workerData = { shared, port: workerPort, packageVersion };
-
-  // the bundle does currently not include the worker module, so this is a temporary workaround for that
-  // todo: handle this in a better way
-  const workerFile = fs.existsSync(path.join(__dirname, '/rules/workers/downloadPackages.js'))
-    ? '/rules/workers/downloadPackages.js'
-    : '/downloadPackages.js';
-  new Worker(path.join(__dirname, workerFile), {
+  // This path looks odd because it's relative to index.js file where
+  // this code ends up being bundled to.
+  new Worker(path.join(__dirname, "rules/workers/downloadPackages"), {
     workerData,
     transferList: [workerPort],
   });

--- a/src/rules/installPackages.ts
+++ b/src/rules/installPackages.ts
@@ -1,13 +1,11 @@
-import path from "path";
 import { Worker, MessageChannel, receiveMessageOnPort } from "worker_threads";
 
 export function installPackages(packageVersion: string) {
   const { port1: localPort, port2: workerPort } = new MessageChannel();
   const shared = new SharedArrayBuffer(4);
   const workerData = { shared, port: workerPort, packageVersion };
-  // This path looks odd because it's relative to index.js file where
-  // this code ends up being bundled to.
-  new Worker(path.join(__dirname, "rules/workers/downloadPackages"), {
+
+  new Worker(new URL("./workers/downloadPackages.js", import.meta.url), {
     workerData,
     transferList: [workerPort],
   });

--- a/src/rules/workers/downloadPackages.ts
+++ b/src/rules/workers/downloadPackages.ts
@@ -1,23 +1,23 @@
-const fs = require('fs');
-const path = require('path');
-const workerData = require('worker_threads').workerData;
-const fetch = require('node-fetch-commonjs');
-const os = require('os');
-const { spawnSync } = require('child_process');
-const { extract } = require('tar/x');
+import fs from "fs";
+import path from "path";
+import { workerData } from "worker_threads";
+import fetch from "node-fetch-commonjs";
+import os from "os";
+import { spawnSync } from "child_process";
+import { extract } from "tar/x";
 
-/* 
+/*
  This worker tread receives the package version from the main thread and returns the path to the packages on disk.
  If a package has been downloaded before, it will be cached and not downloaded again.
 
- Large chunks of this code are copied from the Levitate code base. Why not use the Levitate code directly? 
+ Large chunks of this code are copied from the Levitate code base. Why not use the Levitate code directly?
  Levitate doesn't support cjs modules which is required for the worker thread.
  */
 
 const { shared, port, packageVersion } = workerData;
 const shouldCacheExternal = true;
 
-function pathExists(path) {
+function pathExists(path: string) {
   try {
     fs.accessSync(path, fs.constants.R_OK);
     return true;
@@ -26,24 +26,26 @@ function pathExists(path) {
   }
 }
 
-function getTmpFolderName(packageName) {
-  return path.resolve(path.join(os.tmpdir(), packageName));
+function getTmpFolderName(packageName: string) {
+  return path.resolve(
+    path.join(os.tmpdir(), "grafana-eslint-compatible", packageName)
+  );
 }
 
-async function getPackageTarBallUrl(packageName) {
-  const { stdout } = spawnSync('npm', ['view', packageName, 'dist.tarball']);
+async function getPackageTarBallUrl(packageName: string) {
+  const { stdout } = spawnSync("npm", ["view", packageName, "dist.tarball"]);
 
   return stdout.toString().trim();
 }
 
-async function removeTmpFolder(packageName, ignoreCache = false) {
+async function removeTmpFolder(packageName: string, ignoreCache = false) {
   const tmpPackageFolder = getTmpFolderName(packageName);
   if (!shouldCacheExternal || ignoreCache) {
-    spawnSync('rm', ['-rf', tmpPackageFolder]);
+    spawnSync("rm", ["-rf", tmpPackageFolder]);
   }
 }
 
-async function createTmpPackageFolder(packageName) {
+async function createTmpPackageFolder(packageName: string) {
   const tmpPackageFolder = getTmpFolderName(packageName);
   await removeTmpFolder(packageName);
   fs.mkdirSync(tmpPackageFolder, { recursive: true });
@@ -51,49 +53,57 @@ async function createTmpPackageFolder(packageName) {
   return tmpPackageFolder;
 }
 
-async function downloadFile(url, path) {
+async function downloadFile(url: string, path: string) {
   const res = await fetch(url);
   const fileStream = fs.createWriteStream(path);
 
   await new Promise((resolve, reject) => {
-    res.body.pipe(fileStream);
-    res.body.on('error', reject);
-    fileStream.on('finish', resolve);
+    if (res && res.body) {
+      res.body.pipe(fileStream);
+      res.body.on("error", reject);
+      fileStream.on("finish", resolve);
+    } else {
+      reject(new Error("Failed to download file"));
+    }
   });
 }
 
-async function downloadNpmPackageAsTarball(packageName) {
+async function downloadNpmPackageAsTarball(packageName: string) {
   const tmpFolderName = await createTmpPackageFolder(packageName);
   const url = await getPackageTarBallUrl(packageName);
 
   if (!url) {
     await removeTmpFolder(packageName, true);
-    throw new Error(`Could not resolve package "${packageName}". Are you sure it exists?`);
+    throw new Error(
+      `Could not resolve package "${packageName}". Are you sure it exists?`
+    );
   }
 
   const tarballPath = path.join(tmpFolderName, path.basename(url));
-  const shouldDownload = !pathExists(tarballPath) || !(shouldCacheExternal && pathExists(tarballPath));
+  const shouldDownload =
+    !pathExists(tarballPath) ||
+    !(shouldCacheExternal && pathExists(tarballPath));
 
   if (shouldDownload) {
     await downloadFile(url, tarballPath);
     extract({ C: tmpFolderName, file: tarballPath, sync: true });
   } else {
-    console.log('\nUsing download cache. Flag passed: LEVITATE_CACHE=true');
+    console.log("\nUsing download cache. Flag passed: LEVITATE_CACHE=true");
   }
 
-  return path.join(tmpFolderName, 'package');
+  return path.join(tmpFolderName, "package");
 }
 
-function readJsonFile(path) {
+function readJsonFile(path: string) {
   const content = fs.readFileSync(path);
   return JSON.parse(content.toString());
 }
 
-function getPackageJsonPath(packagePath) {
-  return path.join(packagePath, 'package.json');
+function getPackageJsonPath(packagePath: string) {
+  return path.join(packagePath, "package.json");
 }
 
-function getPackageJson(packagePath) {
+function getPackageJson(packagePath: string) {
   if (!pathExists(getPackageJsonPath(packagePath))) {
     return null;
   }
@@ -101,13 +111,16 @@ function getPackageJson(packagePath) {
   return readJsonFile(getPackageJsonPath(packagePath));
 }
 
-const TYPE_DEFINITION_FILE_NAME = 'index.d.ts';
-function getTypeDefinitionFilePath(folder) {
+const TYPE_DEFINITION_FILE_NAME = "index.d.ts";
+
+function getTypeDefinitionFilePath(folder: string) {
   const packageJson = getPackageJson(folder);
 
   // if available use the package.json property that references a type definition file
   if (packageJson) {
-    const typeProp = ['types', 'typings'].find((prop) => packageJson[prop] !== undefined);
+    const typeProp = ["types", "typings"].find(
+      (prop) => packageJson[prop] !== undefined
+    );
     if (typeProp) {
       const typeDefinitionFilePath = packageJson[typeProp];
       return path.join(folder, typeDefinitionFilePath);
@@ -117,19 +130,22 @@ function getTypeDefinitionFilePath(folder) {
   return path.join(folder, TYPE_DEFINITION_FILE_NAME);
 }
 
-async function resolvePackage(packageName) {
+async function resolvePackage(packageName: string) {
   const tmpFolder = getTmpFolderName(packageName);
 
   if (pathExists(tmpFolder)) {
-    message = `Package version ${packageVersion} resolved from cache`;
-    return getTypeDefinitionFilePath(path.join(tmpFolder, 'package'));
+    message = `Package version ${packageVersion} resolved from cache at ${tmpFolder}`;
+    return getTypeDefinitionFilePath(path.join(tmpFolder, "package"));
   }
 
   const installedPackagePath = await downloadNpmPackageAsTarball(packageName);
-  const typeDefinitionFilePath = getTypeDefinitionFilePath(installedPackagePath);
+  const typeDefinitionFilePath =
+    getTypeDefinitionFilePath(installedPackagePath);
 
   if (!pathExists(typeDefinitionFilePath)) {
-    const errorMsg = `Could not find type definition file at "${getTypeDefinitionFilePath(localPath)}"`;
+    const errorMsg = `Could not find type definition file at "${getTypeDefinitionFilePath(
+      installedPackagePath
+    )}"`;
     console.error(errorMsg);
     throw new Error(errorMsg);
   }
@@ -137,10 +153,10 @@ async function resolvePackage(packageName) {
   return typeDefinitionFilePath;
 }
 
-const packagePaths = {
-  '@grafana/ui': '',
-  '@grafana/data': '',
-  '@grafana/runtime': '',
+const packagePaths: Record<string, string> = {
+  "@grafana/ui": "",
+  "@grafana/data": "",
+  "@grafana/runtime": "",
 };
 
 let message = `Successfully installed version ${packageVersion}`;
@@ -148,8 +164,8 @@ let message = `Successfully installed version ${packageVersion}`;
 const installPackages = async () => {
   return Promise.all(
     Object.keys(packagePaths).map((key) => {
-      return new Promise((resolve) => {
-        resolvePackage(key + '@' + packageVersion)
+      return new Promise<void>((resolve) => {
+        resolvePackage(key + "@" + packageVersion)
           .then((p) => {
             packagePaths[key] = p;
             resolve();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "sourceMap": false,
     "target": "es2020",
     "rootDir": "src/",
-    "outDir": "lib/"
+    "outDir": "dist/"
   },
-  "include": ["src/**/*.ts", "src/rules/workers/downloadPackages.js"]
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
This PR makes the following changes to the build setup:

- [x] Makes Typescript a linter by using noEmit
- [x] Uses only tsup to build the package
- [x] Stops tsup bundling so the worker path is consistent
- [x] Sets tsup to add shims for `import.meta.url` to work in commonjs land.
- [x] Adds concurrently so `npm run start` kicks off both tsc and tsup for development
- [x] Migrates the worker to ts
- [x] Ignores spec files when building to dist

Note: I cannot get the tests to do anything in this branch. They hang. But I've also noticed the same thing happens if I try running them on main. 🤔 

You can test it in a plugin with:

- run `npm i && npm run build && npm pack` with this branch checked out.
- navigate to a plugin and run `npm add ../../path/to/this/repo/clone`.
- add the eslintrc config for the plugin.