### PR TITLE
Fix: GetPackageExports works regardless of version

### DIFF
--- a/src/rules/getPackageExports.ts
+++ b/src/rules/getPackageExports.ts
@@ -9,25 +9,64 @@ const packages = ["@grafana/data", "@grafana/ui", "@grafana/runtime"];
 
 export function downloadPackages(tempDir: string, version: string) {
   console.log(
-    `Please wait... downloading Grafana NPM packages ${tempDir} for version ${version}`
+    `Please wait... downloading Grafana types information for version ${version}.`
   );
   mkdirSync(tempDir, { recursive: true });
-  execSync("npm init -y", { cwd: tempDir });
-  execSync(
-    `npm install ${packages.join(
-      `@${version} `
-    )} --legacy-peer-deps --ignore-scripts --no-save --loglevel=error`,
-    {
-      cwd: tempDir,
-    }
-  );
+  const [major, minor] = version.split(".");
+  // Before Grafana 9.2 bundles didn't have a dist directory and types files were scattered across the package.
+  if (parseInt(major) < 9 || (parseInt(major) === 9 && parseInt(minor) < 2)) {
+    execSync(
+      `npm install ${packages.join(
+        `@${version} `
+      )} --legacy-peer-deps --ignore-scripts --no-save --omit=optional --omit=dev --omit=peer --loglevel=error`,
+      {
+        cwd: tempDir,
+      }
+    );
+  } else {
+    // Starting from Grafana 9.2, types files are bundled in the dist directory as a single file.
+    packages.forEach((pkgName) => {
+      let typesFileUrl = `https://cdn.jsdelivr.net/npm/${pkgName}@${version}/dist/index.d.ts`;
+      let downloadPath = join(tempDir, "node_modules", pkgName);
+      mkdirSync(downloadPath, { recursive: true });
+
+      try {
+        execSync(
+          `node -e "const https = require('https'); https.get('${typesFileUrl}', (res) => {
+            let data = '';
+            res.on('data', chunk => data += chunk);
+            res.on('end', () => {
+              if (res.statusCode === 200) {
+                require('fs').writeFileSync('${join(
+                  downloadPath,
+                  `index.d.ts`
+                )}', data);
+                process.exit(0);
+              }
+              console.error('Failed to download ${pkgName}: HTTP status ' + res.statusCode);
+              process.exit(1);
+            });
+          }).on('error', (e) => {
+            console.error('Failed to download ${pkgName}: ' + e.message);
+            process.exit(1);
+          })"`
+        );
+      } catch (error) {
+        if (error instanceof Error) {
+          throw new Error(
+            `Failed to download types for ${pkgName}@${version}: ${error.message}`
+          );
+        }
+      }
+    });
+  }
 }
 
 function getPackageExportPaths(tempDir: string): Record<string, string> {
   return packages.reduce(
     (acc, pkg) => ({
       ...acc,
-      [pkg]: join(tempDir, "node_modules", pkg, "dist", "index.d.ts"),
+      [pkg]: join(tempDir, "node_modules", pkg, "index.d.ts"),
     }),
     {}
   );


### PR DESCRIPTION
This PR fixes a bug due to grafana npm packages < 9.2 not having a `dist` directory which was causing the lint rule to not report warnings as it silently failed to find types files. Additionally initial linting is greatly sped up if the version passed is > 9.2. 

Locally, running the tests that pull the packages(cold cache) now pass in ~2.5s. Doing the same against `main` currently takes ~30s locally as npm installs 350 packages. CI test step drops from [~22s](https://github.com/grafana/eslint-plugin-is-compatible/actions/runs/13133398655/job/36643315415) to [~12s](https://github.com/grafana/eslint-plugin-is-compatible/actions/runs/13156307202/job/36714125017). 🚀 
 
This PR addresses the following issues:

- [x] Normalise package export paths so regardless of package version the path is consistent. e.g. `${tmpDir}/node_modules/${pkg}/index.d.ts`.
- [x] To speed up initial linting, if version passed in is > 9.2 only download the single types file via `cdn.jsdelivr.net` rather than use npm to install the package and all its dependencies.


